### PR TITLE
fix: Missing return type for handle_http_exception()

### DIFF
--- a/flask_smorest-stubs/error_handler.pyi
+++ b/flask_smorest-stubs/error_handler.pyi
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 import marshmallow as ma
 from werkzeug.exceptions import HTTPException
@@ -12,4 +12,4 @@ class ErrorSchema(ma.Schema):
 class ErrorHandlerMixin:
     ERROR_SCHEMA: type[ErrorSchema]
 
-    def handle_http_exception(self, error: HTTPException) -> tuple[dict[str, Any], Any, dict[str, Any]]: ...
+    def handle_http_exception(self, error: HTTPException) -> tuple[dict[str, Any], Optional[int], dict[str, Any]]: ...

--- a/flask_smorest-stubs/error_handler.pyi
+++ b/flask_smorest-stubs/error_handler.pyi
@@ -1,4 +1,3 @@
-from builtins import type
 from typing import Any
 
 import marshmallow as ma
@@ -13,4 +12,4 @@ class ErrorSchema(ma.Schema):
 class ErrorHandlerMixin:
     ERROR_SCHEMA: type[ErrorSchema]
 
-    def handle_http_exception(self, error: HTTPException): ...
+    def handle_http_exception(self, error: HTTPException) -> tuple[dict[str, Any], Any, dict[str, Any]]: ...


### PR DESCRIPTION
Missed stubbing this yesterday (and the linters didn't catch it :/)